### PR TITLE
feat: Running metricbeat+awsbeats on Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 ARG GO_VERSION=${GO_VERSION:-1.10.2}
 # Used from within the second FROM
 ARG BEATS_VERSION=${BEATS_VERSION:-6.1.2}
+ARG BEAT_NAME=${BEAT_NAME:-filebeat}
 
 FROM golang:${GO_VERSION} AS awsbeats
 
@@ -15,6 +16,7 @@ WORKDIR /go/src/github.com/s12v/awsbeats
 ARG BEATS_VERSION=${BEATS_VERSION:-6.1.2}
 ARG GO_PLATFORM=${GO_PLATFORM:-linux-amd64}
 ARG AWSBEATS_VERSION=${AWSBEATS_VERSION:-1-snapshot}
+ARG BEAT_NAME=${BEAT_NAME:-filebeat}
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 RUN go get github.com/elastic/beats || true
 RUN /go/bin/dep ensure
@@ -34,13 +36,14 @@ WORKDIR /build
 ARG BEATS_VERSION=${BEATS_VERSION:-6.1.2}
 ARG GO_VERSION=${GO_VERSION:-1.10.2}
 ARG GO_PLATFORM=${GO_PLATFORM:-linux-amd64}
+ARG BEAT_NAME=${BEAT_NAME:-filebeat}
 
 RUN go get github.com/elastic/beats || true
 # Beats requires CGO for plugin support as per https://github.com/elastic/beats/commit/d21decb720e7fdeb986f4ebac413cc816353aa55
 RUN CGO_ENABLED=1 make beats && \
   pwd && find ./target
 
-FROM docker.elastic.co/beats/filebeat:${BEATS_VERSION}
+FROM docker.elastic.co/beats/${BEAT_NAME}:${BEATS_VERSION}
 
 LABEL maintainr "Yusuke KUOKA <ykuoka@gmail.com>"
 
@@ -48,10 +51,10 @@ ARG AWSBEATS_VERSION=${AWSBEATS_VERSION:-1-snapshot}
 ARG BEATS_VERSION=${BEATS_VERSION:-6.1.2}
 ARG GO_VERSION=${GO_VERSION:-1.10.2}
 ARG GO_PLATFORM=${GO_PLATFORM:-linux-amd64}
-ARG BEAT=${BEAT:-filebeat}
+ARG BEAT_NAME=${BEAT_NAME:-filebeat}
 
-COPY --from=awsbeats /go/src/github.com/s12v/awsbeats/target/kinesis-${AWSBEATS_VERSION}-${BEATS_VERSION}-go${GO_VERSION}-linux-amd64.so /usr/share/${BEAT}/kinesis.so
-COPY --from=beats /build/target/${BEAT}-${BEATS_VERSION}-go${GO_VERSION}-linux-amd64 /usr/share/${BEAT}/${BEAT}
+COPY --from=awsbeats /go/src/github.com/s12v/awsbeats/target/kinesis-${AWSBEATS_VERSION}-${BEATS_VERSION}-go${GO_VERSION}-linux-amd64.so /usr/share/${BEAT_NAME}/kinesis.so
+COPY --from=beats /build/target/${BEAT_NAME}-${BEATS_VERSION}-go${GO_VERSION}-linux-amd64 /usr/share/${BEAT_NAME}/${BEAT_NAME}
 
 # Usage:
 #   docker run --rm s12v/awsbeats:canary cat filebeat.yml > filebeat.yml

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -79,6 +79,12 @@
   version = "v0.8.0"
 
 [[projects]]
+  name = "github.com/rs/xid"
+  packages = ["."]
+  revision = "02dd45c33376f85d1064355dc790dcc4850596b1"
+  version = "v1.1"
+
+[[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
@@ -151,6 +157,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a5688a1fc073696b264ed903c703edf179cca5332bfefde5ccfc0ec4a55db9a2"
+  inputs-digest = "d58e2102fe912fdb1f2c8c737d54d07094e019ee3c0f183bfc1d35746a9a6ac8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,3 +33,7 @@ ignored = ["github.com/elastic/beats"]
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/rs/xid"
+  version = "1.1.0"

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ GO_PLATFORM ?= $(shell go version | cut -d ' ' -f 4 | sed -e 's/ /-/g' | sed -e 
 BEATS_VERSION ?= "master"
 BEATS_TAG ?= $(shell echo ${BEATS_VERSION} | sed 's/[^[:digit:]]*\([[:digit:]]*\(\.[[:digit:]]*\)\)/v\1/')
 AWSBEATS_VERSION ?= "1-snapshot"
+BEAT_NAME ?= "filebeat"
 DOCKER_IMAGE ?= s12v/awsbeats
-DOCKER_TAG ?= canary
+DOCKER_TAG ?= $(BEAT_NAME)-canary
 
 .PHONY: all
 all: vars test beats build
@@ -38,16 +39,16 @@ build: format
 
 beats:
 ifdef BEATS_VERSION
-	@echo "Building filebeats:$(BEATS_VERSION)..."
+	@echo "Building $(BEAT_NAME):$(BEATS_VERSION)..."
 	@mkdir -p "$(CURDIR)/target"
-	@cd "$$GOPATH/src/github.com/elastic/beats/filebeat" &&\
+	@cd "$$GOPATH/src/github.com/elastic/beats/$(BEAT_NAME)" &&\
 	git checkout $(BEATS_TAG) &&\
 	make &&\
-	mv filebeat "$(CURDIR)/target/filebeat-$(BEATS_VERSION)-go$(GO_VERSION)-$(GO_PLATFORM)"
+	mv $(BEAT_NAME) "$(CURDIR)/target/$(BEAT_NAME)-$(BEATS_VERSION)-go$(GO_VERSION)-$(GO_PLATFORM)"
 else
 	$(error BEATS_VERSION is undefined)
 endif
 
 .PHONY: dockerimage
 dockerimage:
-	docker build --build-arg AWSBEATS_VERSION=$(AWSBEATS_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg BEATS_VERSION=$(BEATS_VERSION) -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+	docker build --build-arg AWSBEATS_VERSION=$(AWSBEATS_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg BEATS_VERSION=$(BEATS_VERSION) --build-arg BEAT_NAME=$(BEAT_NAME) -t $(DOCKER_IMAGE):$(DOCKER_TAG) .

--- a/example/metricbeat/metricbeat.configmap.yaml
+++ b/example/metricbeat/metricbeat.configmap.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metricbeat-config
+  namespace: kube-system
+  labels:
+    k8s-app: metricbeat
+    kubernetes.io/cluster-service: "true"
+data:
+  metricbeat.yml: |-
+    metricbeat.config.modules:
+      # Mounted `metricbeat-daemonset-modules` configmap:
+      path: ${path.config}/modules.d/*.yml
+      # Reload module configs as they change:
+      reload.enabled: false
+
+    processors:
+      - add_cloud_metadata:
+
+    output.streams:
+      region: ap-northeast-1
+      stream_name: test1
+      # Use https://github.com/rs/xid to generate a unique ID per event
+      partition_key_generator: xid
+
+    queue.mem:
+      events: 4096
+      flush.min_events: 5
+      flush.timeout: 3s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metricbeat-daemonset-modules
+  namespace: kube-system
+  labels:
+    k8s-app: metricbeat
+    kubernetes.io/cluster-service: "true"
+data:
+  system.yml: |-
+    - module: system
+      period: 10s
+      metricsets:
+        - cpu
+        - load
+        - memory
+        - network
+        - process
+        - process_summary
+        #- core
+        #- diskio
+        #- socket
+      processes: ['.*']
+      process.include_top_n:
+        by_cpu: 5      # include top 5 processes by CPU
+        by_memory: 5   # include top 5 processes by memory
+
+    - module: system
+      period: 1m
+      metricsets:
+        - filesystem
+        - fsstat
+      processors:
+      - drop_event.when.regexp:
+          system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib)($|/)'
+  kubernetes.yml: |-
+    - module: kubernetes
+      metricsets:
+        - node
+        - system
+        - pod
+        - container
+        - volume
+      period: 10s
+      hosts: ["localhost:10255"]

--- a/example/metricbeat/metricbeat.configmap.yaml
+++ b/example/metricbeat/metricbeat.configmap.yaml
@@ -22,7 +22,7 @@ data:
       region: ap-northeast-1
       stream_name: test1
       # Use https://github.com/rs/xid to generate a unique ID per event
-      partition_key_generator: xid
+      partition_key_provider: xid
 
     queue.mem:
       events: 4096

--- a/streams/config.go
+++ b/streams/config.go
@@ -6,13 +6,14 @@ import (
 )
 
 type StreamsConfig struct {
-	Region             string        `config:"region"`
-	DeliveryStreamName string        `config:"stream_name"`
-	PartitionKey       string        `config:"partition_key"`
-	BatchSize          int           `config:"batch_size"`
-	MaxRetries         int           `config:"max_retries"`
-	Timeout            time.Duration `config:"timeout"`
-	Backoff            backoff       `config:"backoff"`
+	Region               string        `config:"region"`
+	DeliveryStreamName   string        `config:"stream_name"`
+	PartitionKey         string        `config:"partition_key"`
+	PartitionKeyProvider string        `config:"partition_key_provider"`
+	BatchSize            int           `config:"batch_size"`
+	MaxRetries           int           `config:"max_retries"`
+	Timeout              time.Duration `config:"timeout"`
+	Backoff              backoff       `config:"backoff"`
 }
 
 type backoff struct {
@@ -48,6 +49,10 @@ func (c *StreamsConfig) Validate() error {
 
 	if c.BatchSize > maxBatchSize || c.BatchSize < 1 {
 		return errors.New("invalid batch size")
+	}
+
+	if c.PartitionKeyProvider != "" && c.PartitionKeyProvider != "xid" {
+		return errors.New("invalid partition key procider: the only supported provider is `xid`")
 	}
 
 	return nil

--- a/streams/config_test.go
+++ b/streams/config_test.go
@@ -41,3 +41,11 @@ func TestValidateWithRegionAndStreamNameAndInvalidBatchSize0(t *testing.T) {
 		t.Errorf("Expected an error")
 	}
 }
+
+func TestValidateWithRegionAndStreamNameAndInvalidPartitionKeyProvider(t *testing.T) {
+	config := &StreamsConfig{Region: "eu-central-1", DeliveryStreamName: "foo", PartitionKeyProvider: "uuid"}
+	err := config.Validate()
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+}

--- a/streams/partition_key.go
+++ b/streams/partition_key.go
@@ -1,0 +1,47 @@
+package streams
+
+import (
+	"fmt"
+	"github.com/elastic/beats/libbeat/publisher"
+	"github.com/rs/xid"
+)
+
+type PartitionKeyProvider interface {
+	PartitionKeyFor(event *publisher.Event) (string, error)
+}
+
+type fieldPartitionKeyProvider struct {
+	fieldKey string
+}
+
+type xidPartitionKeyProvider struct {
+}
+
+func newFieldPartitionKeyProvider(fieldKey string) *fieldPartitionKeyProvider {
+	return &fieldPartitionKeyProvider{
+		fieldKey: fieldKey,
+	}
+}
+
+func (p *fieldPartitionKeyProvider) PartitionKeyFor(event *publisher.Event) (string, error) {
+	rawPartitionKey, err := event.Content.GetValue(p.fieldKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to get parition key: %v", err)
+	}
+
+	var ok bool
+	partitionKey, ok := rawPartitionKey.(string)
+	if !ok {
+		return "", fmt.Errorf("failed to get partition key: %s(=%v) is found, but not a string", p.fieldKey, rawPartitionKey)
+	}
+
+	return partitionKey, nil
+}
+
+func newXidPartitionKeyProvider() *xidPartitionKeyProvider {
+	return &xidPartitionKeyProvider{}
+}
+
+func (p *xidPartitionKeyProvider) PartitionKeyFor(_ *publisher.Event) (string, error) {
+	return xid.New().String(), nil
+}

--- a/streams/partition_key_test.go
+++ b/streams/partition_key_test.go
@@ -1,0 +1,21 @@
+package streams
+
+import (
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/publisher"
+	"testing"
+)
+
+func TestXidPartitionKey(t *testing.T) {
+	event := &publisher.Event{Content: beat.Event{Fields: common.MapStr{"foo": "bar"}}}
+
+	xidProvider := newXidPartitionKeyProvider()
+	xidKey, err := xidProvider.PartitionKeyFor(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if xidKey == "" || xidKey == "bar" {
+		t.Fatalf("uenxpected partition key: %s", xidKey)
+	}
+}


### PR DESCRIPTION
See the last two commits for changes relevant to this PR.

You can basically build a metricbeat+awsbeats docker image and deploy it to your Kubernetes cluster. I tried hard to not fork the upstream metricbeat deployment manifests. So, it is matter of just git-cloning the upstream elastic/beats repo, replace some parts of the manifests, run `kubectl -f apply`.

I have also added an experimental feature to `streams` output plugin. It is enabled via `partition_key_provider: xid`. This is useful to evenly distribute metricbeat events to Kinesis Data Stream shards for maximum scalability.

The first commit is #23, hence this PR Depends on #23.