### PR TITLE
fix(streams): Fix panicing on a retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,7 @@ endif
 .PHONY: dockerimage
 dockerimage:
 	docker build --build-arg AWSBEATS_VERSION=$(AWSBEATS_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg BEATS_VERSION=$(BEATS_VERSION) --build-arg BEAT_NAME=$(BEAT_NAME) -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+
+.PHONY: filebeat-image
+filebeat-image:
+	@bash -c 'make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 BEAT_NAME=filebeat AWSBEATS_VERSION=$(ref=$(git rev-parse HEAD); ref=${ref:0:7}; echo $ref) GOPATH=$HOME/go'

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ To build a docker image for awsbeats, run `make dockerimage`.
 make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 GOPATH=$HOME/go
 ```
 
+There is also a convenient make target `filebeat-image` with sane defaults:
+
+```console
+make filebeat
+```
+
 **metricbeat**:
 
 ```

--- a/hack/containerized-filebeat
+++ b/hack/containerized-filebeat
@@ -14,7 +14,7 @@ docker run \
   -v $(pwd)/filebeat.yml:/etc/filebeat/filebeat.yml \
   -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
   -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
-  s12v/awsbeats:canary \
+  s12v/awsbeats:filebeat-canary \
   filebeat \
   --plugin kinesis.so \
   -e \

--- a/streams/client.go
+++ b/streams/client.go
@@ -130,6 +130,11 @@ func processFailedDeliveries(res *kinesis.PutRecordsOutput, batch publisher.Batc
 		failedEvents := make([]publisher.Event, 0)
 		records := res.Records
 		for i, r := range records {
+			if r == nil {
+				// See https://github.com/s12v/awsbeats/issues/27 for more info
+				logp.Warn("no record returned from kinesis for event: ", events[i])
+				continue
+			}
 			if *r.ErrorCode != "" {
 				failedEvents = append(failedEvents, events[i])
 			}

--- a/streams/client_test.go
+++ b/streams/client_test.go
@@ -77,10 +77,14 @@ func TestMapEvents(t *testing.T) {
 	client := client{encoder: MockCodec{}, partitionKeyProvider: provider}
 	event := publisher.Event{Content: beat.Event{Fields: common.MapStr{fieldForPartitionKey: expectedPartitionKey}}}
 	events := []publisher.Event{event}
-	records, _ := client.mapEvents(events)
+	okEvents, records, _ := client.mapEvents(events)
 
 	if len(records) != 1 {
 		t.Errorf("Expected 1 records, got %v", len(records))
+	}
+
+	if len(okEvents) != 1 {
+		t.Errorf("Expected 1 ok events, got %v", len(okEvents))
 	}
 
 	if string(records[0].Data) != "boom" {


### PR DESCRIPTION
Turns out awsbeats was calling `batch.RetryEvents` on different data and timing. Revise the implementation according to the [official beat outputs](https://github.com/elastic/beats/blob/c4af03c51373c1de7daaca660f5d21b3f602771c/libbeat/outputs/elasticsearch/client.go#L234)

Fixes #29