### PR TITLE
feat(docker): APM Server + Awsbeats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ FROM golang:${GO_VERSION} AS awsbeats
 
 LABEL maintainr "Yusuke KUOKA <ykuoka@gmail.com>"
 
-ADD . /go/src/github.com/s12v/awsbeats
+# "MAINTAINER" is deprecated in favor of the above label. But required to make codacy happy
+MAINTAINER Yusuke KUOKA <ykuoka@gmail.com>
+
+COPY . /go/src/github.com/s12v/awsbeats
 
 WORKDIR /go/src/github.com/s12v/awsbeats
 
@@ -28,7 +31,7 @@ FROM golang:${GO_VERSION} AS beats
 
 LABEL maintainr "Yusuke KUOKA <ykuoka@gmail.com>"
 
-ADD Makefile /build/Makefile
+COPY Makefile /build/Makefile
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # Used from within the first FROM
 ARG GO_VERSION=${GO_VERSION:-1.10.2}
 # Used from within the second FROM
-ARG BEATS_VERSION=${BEATS_VERSION:-6.1.2}
-ARG BEAT_NAME=${BEAT_NAME:-filebeat}
+ARG BEAT_DOCKER_IMAGE
 
 FROM golang:${GO_VERSION} AS awsbeats
 
@@ -37,13 +36,15 @@ ARG BEATS_VERSION=${BEATS_VERSION:-6.1.2}
 ARG GO_VERSION=${GO_VERSION:-1.10.2}
 ARG GO_PLATFORM=${GO_PLATFORM:-linux-amd64}
 ARG BEAT_NAME=${BEAT_NAME:-filebeat}
+ARG BEAT_GITHUB_REPO
+ARG BEAT_GO_PKG
 
-RUN go get github.com/elastic/beats || true
+#RUN go get github.com/elastic/beats || true
 # Beats requires CGO for plugin support as per https://github.com/elastic/beats/commit/d21decb720e7fdeb986f4ebac413cc816353aa55
 RUN CGO_ENABLED=1 make beats && \
   pwd && find ./target
 
-FROM docker.elastic.co/beats/${BEAT_NAME}:${BEATS_VERSION}
+FROM ${BEAT_DOCKER_IMAGE}
 
 LABEL maintainr "Yusuke KUOKA <ykuoka@gmail.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ AWSBEATS_VERSION ?= "1-snapshot"
 BEAT_NAME ?= "filebeat"
 DOCKER_IMAGE ?= s12v/awsbeats
 DOCKER_TAG ?= $(BEAT_NAME)-canary
+BEAT_GITHUB_REPO ?= github.com/elastic/beats
+BEAT_GO_PKG ?= $(BEAT_GITHUB_REPO)/$(BEAT_NAME)
+BEAT_DOCKER_IMAGE ?= docker.elastic.co/beats/$(BEAT_NAME):$(BEATS_VERSION)
+GOPATH ?= $(HOME)/go
 
 .PHONY: all
 all: vars test beats build
@@ -29,7 +33,7 @@ format:
 
 build: format
 	@echo "Building the plugin with: BEATS_VERSION=$(BEATS_VERSION) GO_VERSION=$(GO_VERSION) GO_PLATFORM=$(GO_PLATFORM)"
-	@cd "$$GOPATH/src/github.com/elastic/beats/filebeat" && \
+	@cd "$$GOPATH/src/github.com/elastic/beats" && \
 	git checkout $(BEATS_TAG) && \
 	cd "$(CURDIR)"
 	go build -buildmode=plugin ./plugins/kinesis
@@ -37,22 +41,51 @@ build: format
 	@mv kinesis.so "$(CURDIR)/target/kinesis-$(AWSBEATS_VERSION)-$(BEATS_VERSION)-go$(GO_VERSION)-$(GO_PLATFORM).so"
 	@find "$(CURDIR)"/target/
 
-beats:
+beats: $(GOPATH)/src/$(BEAT_GITHUB_REPO) $(GOPATH)/src/github.com/elastic/beats
 ifdef BEATS_VERSION
 	@echo "Building $(BEAT_NAME):$(BEATS_VERSION)..."
 	@mkdir -p "$(CURDIR)/target"
-	@cd "$$GOPATH/src/github.com/elastic/beats/$(BEAT_NAME)" &&\
-	git checkout $(BEATS_TAG) &&\
+	@cd "$$GOPATH/src/$(BEAT_GO_PKG)" &&\
+	git checkout $(BEATS_TAG)
+ifneq ($(GOPATH)/src/$(BEAT_GITHUB_REPO),$(GOPATH)/src/github.com/elastic/beats)
+	@echo "Checking out beats $(BEATS_VERSION)"
+	@cd "$$GOPATH/src/github.com/elastic/beats" &&\
+	git checkout $(BEATS_TAG)
+	@echo "Removing vendored libbeat to avoid `flag redefined` errors for the beat outside of the elsatic/beats repo"
+	rm -rf "$$GOPATH/src/$(BEAT_GO_PKG)/vendor/github.com/elastic/beats"
+	# Work-around for the following build error:
+	# cmd/root.go:21:72: cannot use runFlags (type *"github.com/elastic/apm-server/vendor/github.com/spf13/pflag".FlagSet) as type *"github.com/elastic/beats/vendor/github.com/spf13/pflag".FlagSet in argument to cmd.GenRootCmdWithIndexPrefixWithRunFlags
+	rm -rf "$$GOPATH/src/$(BEAT_GO_PKG)/vendor/github.com/spf13/pflag"
+	rm -rf "$$GOPATH/src/github.com/elastic/beats/vendor/github.com/spf13/pflag"
+	go get github.com/spf13/pflag
+endif
+	@cd "$$GOPATH/src/$(BEAT_GO_PKG)" &&\
 	make &&\
 	mv $(BEAT_NAME) "$(CURDIR)/target/$(BEAT_NAME)-$(BEATS_VERSION)-go$(GO_VERSION)-$(GO_PLATFORM)"
 else
 	$(error BEATS_VERSION is undefined)
 endif
 
+$(GOPATH)/src/$(BEAT_GITHUB_REPO):
+	go get $(BEAT_GITHUB_REPO) || true
+
+ifneq ($(GOPATH)/src/$(BEAT_GITHUB_REPO),$(GOPATH)/src/github.com/elastic/beats)
+$(GOPATH)/src/github.com/elastic/beats:
+	go get github.com/elastic/beats || true
+endif
+
 .PHONY: dockerimage
 dockerimage:
-	docker build --build-arg AWSBEATS_VERSION=$(AWSBEATS_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg BEATS_VERSION=$(BEATS_VERSION) --build-arg BEAT_NAME=$(BEAT_NAME) -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+	docker build --build-arg AWSBEATS_VERSION=$(AWSBEATS_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg BEAT_GITHUB_REPO=$(BEAT_GITHUB_REPO) --build-arg BEAT_GO_PKG=$(BEAT_GO_PKG) --build-arg BEAT_DOCKER_IMAGE=$(BEAT_DOCKER_IMAGE) --build-arg BEATS_VERSION=$(BEATS_VERSION) --build-arg BEAT_NAME=$(BEAT_NAME) -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
 
 .PHONY: filebeat-image
 filebeat-image:
 	@bash -c 'make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 BEAT_NAME=filebeat AWSBEATS_VERSION=$(ref=$(git rev-parse HEAD); ref=${ref:0:7}; echo $ref) GOPATH=$HOME/go'
+
+.PHONY: metricbeat-image
+metricbeat-image:
+	@bash -c 'make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 BEAT_NAME=metricbeat AWSBEATS_VERSION=$(ref=$(git rev-parse HEAD); ref=${ref:0:7}; echo $ref) GOPATH=$HOME/go'
+
+.PHONY: apm-server-image
+apm-server-image:
+	@bash -c 'make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 BEAT_NAME=apm-server BEAT_GITHUB_REPO=github.com/elastic/apm-server BEAT_GO_PKG=github.com/elastic/apm-server BEAT_DOCKER_IMAGE=docker.elastic.co/apm/apm-server:6.2.4 AWSBEATS_VERSION=$(ref=$(git rev-parse HEAD); ref=${ref:0:7}; echo $ref) GOPATH=$HOME/go'

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ kinesis.so-1-snapshot-v6.1.3-go1.10rc1-linux-amd64
 
 To build a docker image for awsbeats, run `make dockerimage`.
 
-**filebeat**:
+### filebeat
 
 ```
 make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 GOPATH=$HOME/go
@@ -74,16 +74,10 @@ make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 GOPATH=$HOME/go
 There is also a convenient make target `filebeat-image` with sane defaults:
 
 ```console
-make filebeat
+make filebeat-image
 ```
 
-**metricbeat**:
-
-```
-make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 BEAT_NAME=metricbeat GOPATH=$HOME/go
-```
-
-The resulting docker image is tagged `s12v/awsbeats:canary`.  It contains a custom build of filebeat and the plugin, along with all the relevant files from the official filebeat docker image.
+The resulting docker image is tagged `s12v/awsbeats:filebeat-canary`.  It contains a custom build of filebeat and the plugin, along with all the relevant files from the official filebeat docker image.
 
 To try running it, provide AWS credentials via e.g. envvars and run `hack/dockerized-filebeat`:
 
@@ -98,6 +92,26 @@ Emit some line-delimited json log messages:
 
 ```
 hack/emit-ndjson-logs
+```
+
+### metricbeat
+
+**metricbeat**:
+
+```
+make dockerimage BEATS_VERSION=6.2.4 GO_VERSION=1.10.2 BEAT_NAME=metricbeat GOPATH=$HOME/go
+
+# Or:
+
+make metricbeat-image
+```
+
+### apm-server
+
+```
+make apm-server-image
+
+hack/containerized-apm-server
 ```
 
 ## Running awsbeats on a Kubernetes cluster

--- a/example/apm-server/apm-server.yml
+++ b/example/apm-server/apm-server.yml
@@ -1,0 +1,13 @@
+processors:
+- add_cloud_metadata:
+
+output:
+  streams:
+    region: ap-northeast-1
+    stream_name: kuokatest1
+    partition_key_provider: xid
+
+queue.mem:
+  events: 4096
+  flush.min_events: 5
+  flush.timeout: 3s

--- a/example/apm-server/apm-server.yml
+++ b/example/apm-server/apm-server.yml
@@ -1,5 +1,13 @@
 processors:
 - add_cloud_metadata:
+# Match originating pod enrich apm events with metadata from Kubernetes
+# See https://github.com/elastic/apm-server/issues/349 for more details
+#- add_kubernetes_metadata:
+#    indexers:
+#      - ip_port:
+#    matchers:
+#      - fields:
+#          lookup_fields: ["context.system.ip"]
 
 output:
   streams:

--- a/hack/containerized-apm-server
+++ b/hack/containerized-apm-server
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+docker run \
+  --rm \
+  -v $(pwd)/logs:/mnt/log/ \
+  -v $(pwd)/example/apm-server:/etc/apm-server \
+  -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+  -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+  s12v/awsbeats:apm-server-canary \
+  apm-server \
+  --plugin kinesis.so \
+  -e \
+  -d '*' \
+  -c /etc/apm-server/apm-server.yml \
+  --strict.perms=false
+
+# Note that `strict.perms` seems to be required due to https://discuss.elastic.co/t/volume-mapped-filebeat-yml-permissions-from-docker-on-windows-host/91893/2


### PR DESCRIPTION
[Elastic APM Server](https://github.com/elastic/apm-server) + Awsbeats can be run inside a docker container. It allows you to send APM transactions and spans via e.g. the Kinesis Streams output plugin.

Resolves #32