### PR TITLE
Beats version 6.4.0 support

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 #   go-tests = true
 #   unused-packages = true
 
-ignored = ["github.com/elastic/beats"]
+ignored = ["github.com/elastic/beats*"]
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKE_VARIABLES := $(.VARIABLES)
 
 GO_VERSION=$(shell go version | cut -d ' ' -f 3 | sed -e 's/ /-/g' | sed -e 's/\//-/g' | sed -e 's/^go//g')
 GO_PLATFORM ?= $(shell go version | cut -d ' ' -f 4 | sed -e 's/ /-/g' | sed -e 's/\//-/g')
-BEATS_VERSION ?= "6.3.0"
+BEATS_VERSION ?= "6.4.0"
 BEATS_TAG ?= $(shell echo ${BEATS_VERSION} | sed 's/[^[:digit:]]*\([[:digit:]]*\(\.[[:digit:]]*\)\)/v\1/')
 AWSBEATS_VERSION ?= $(shell script/version)
 BEAT_NAME ?= "filebeat"

--- a/firehose/client.go
+++ b/firehose/client.go
@@ -27,7 +27,7 @@ func newClient(sess *session.Session, config *FirehoseConfig, observer outputs.O
 		firehose:           firehose.New(sess),
 		deliveryStreamName: config.DeliveryStreamName,
 		beatName:           beat.Beat,
-		encoder:            json.New(false, beat.Version),
+		encoder:            json.New(false, true, beat.Version),
 		timeout:            config.Timeout,
 		observer:           observer,
 	}

--- a/streams/client.go
+++ b/streams/client.go
@@ -35,7 +35,7 @@ func newClient(sess *session.Session, config *StreamsConfig, observer outputs.Ob
 		streamName:           config.DeliveryStreamName,
 		partitionKeyProvider: partitionKeyProvider,
 		beatName:             beat.Beat,
-		encoder:              json.New(false, beat.Version),
+		encoder:              json.New(false, true, beat.Version),
 		timeout:              config.Timeout,
 		observer:             observer,
 	}


### PR DESCRIPTION
Elastic beats is now version 6.4.0([release notes](https://www.elastic.co/guide/en/beats/libbeat/6.4/release-notes-6.4.0.html)).  This PR includes following updates to support 6.4.0

* follow up the update at json.New function made at [this PR](https://github.com/elastic/beats/pull/7445). 
* set default beats version 6.4.0 at Makefile
* modify ignored field to skip installing beats into vendor/* in order to avoid to use it for build